### PR TITLE
[FIX] option에 맞는 vote 가져오는 쿼리 메서드 추가

### DIFF
--- a/src/main/java/com/kakao/golajuma/vote/domain/service/DecisionService.java
+++ b/src/main/java/com/kakao/golajuma/vote/domain/service/DecisionService.java
@@ -47,7 +47,7 @@ public class DecisionService {
 
 		VoteEntity voteEntity =
 				voteRepository
-						.findVoteEntityByOption(optionId)
+						.findVoteByOption(optionId)
 						.orElseThrow(() -> new NotFoundException("존재하지 않는 투표 입니다."));
 
 		if (voteEntity.isComplete()) {
@@ -84,7 +84,7 @@ public class DecisionService {
 
 		VoteEntity voteEntity =
 				voteRepository
-						.findVoteEntityByOption(optionId)
+						.findVoteByOption(optionId)
 						.orElseThrow(() -> new NotFoundException("존재하지 않는 투표 입니다."));
 
 		if (voteEntity.isComplete()) {

--- a/src/main/java/com/kakao/golajuma/vote/infra/entity/OptionEntity.java
+++ b/src/main/java/com/kakao/golajuma/vote/infra/entity/OptionEntity.java
@@ -5,6 +5,7 @@ import com.kakao.golajuma.vote.web.dto.request.CreateVoteRequest;
 import javax.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
 
 @ToString
 @SuperBuilder
@@ -31,16 +32,8 @@ public class OptionEntity extends BaseEntity {
 	private String optionImage;
 
 	@Column(name = ENTITY_PREFIX + "_count")
+	@ColumnDefault("0")
 	private long optionCount;
-
-	@Builder
-	public OptionEntity(long id, long voteId, String optionName, String optionImage) {
-		this.id = id;
-		this.voteId = voteId;
-		this.optionName = optionName;
-		this.optionImage = optionImage;
-		this.optionCount = 0;
-	}
 
 	public static OptionEntity createEntity(CreateVoteRequest.OptionDTO request, long voteId) {
 		return OptionEntity.builder()

--- a/src/main/java/com/kakao/golajuma/vote/infra/entity/VoteEntity.java
+++ b/src/main/java/com/kakao/golajuma/vote/infra/entity/VoteEntity.java
@@ -44,26 +44,6 @@ public class VoteEntity extends BaseEntity {
 	@Column(name = ENTITY_PREFIX + "_type")
 	private String voteType;
 
-	@Builder
-	public VoteEntity(
-			long id,
-			long userId,
-			long voteTotalCount,
-			Category category,
-			String voteTitle,
-			String voteContent,
-			LocalDateTime voteEndDate,
-			String voteType) {
-		this.id = id;
-		this.userId = userId;
-		this.voteTotalCount = voteTotalCount;
-		this.category = category;
-		this.voteTitle = voteTitle;
-		this.voteContent = voteContent;
-		this.voteEndDate = voteEndDate;
-		this.voteType = voteType;
-	}
-
 	public Active checkActive() {
 		LocalDateTime now = LocalDateTime.now();
 		if (voteEndDate.isBefore(now)) {

--- a/src/main/java/com/kakao/golajuma/vote/infra/repository/VoteRepository.java
+++ b/src/main/java/com/kakao/golajuma/vote/infra/repository/VoteRepository.java
@@ -106,4 +106,10 @@ public interface VoteRepository extends JpaRepository<VoteEntity, Integer> {
 					+ " order by v.voteTotalCount desc ")
 	Slice<VoteEntity> searchVotesOrderByVoteTotalCount(
 			@Param("keyword") String keyword, @Param("category") Category category, Pageable pageable);
+
+	@Query(
+			"select v from VoteEntity v"
+					+ " join OptionEntity o on o.voteId = v.id"
+					+ " where o.id = :optionId")
+	Optional<VoteEntity> findVoteByOption(Long optionId);
 }


### PR DESCRIPTION
## 어떤 내용에 대한 PR인가요?
option에 맞는 vote 가져오는 쿼리 메서드가 빠져있어 해당 메서드 추가했습니다.

## 변경 사항
변경된 부분에 대한 상세한 내용을 나열해주세요
1.  voteEntity, OptionEntity에 builder 선언이 중복되어 있는 걸 확인했습니다. 해당 중복 사항들 변경했으니 확인해주세요!
2. 추가적으로 columnDefault 어노테이션을 이용해서 테이블 생성 시 기본값 설정해주었습니다.
3. 옵션id를 넘겼을 때 해당 옵션의 vote를 가져오는 쿼리 메서드 추가했습니다.

### 무엇을 위주로 보면 좋을까요?


## 관련된 이슈
closes #108 

## 테스트 방법

